### PR TITLE
[Wfw 8698h9h7n] Add mobile layout for messages and swipes pages

### DIFF
--- a/src/components/swipes/Swipes.tsx
+++ b/src/components/swipes/Swipes.tsx
@@ -108,7 +108,7 @@ const Swipes = () => {
             </Button>
           </Box>
         ) : (
-          <Box sx={{ pr: 4 }}>
+          <Box sx={{ pr: { xs: 0, sm: 4 } }}>
             <UserProfile user={friendsData} />
             <UserProfileButton skip={onSkip} beFriend={onBeFriend} />
           </Box>

--- a/src/components/swipes/SwipesWithFilters.tsx
+++ b/src/components/swipes/SwipesWithFilters.tsx
@@ -3,6 +3,7 @@ import Swipes from './Swipes'
 import NoMoreMatchesDialog from 'pages/NoMoreMatchesDialog'
 import { makeStyles } from 'tss-react/mui'
 import { useRef } from 'react'
+import theme from '../../styles/createTheme'
 
 const SwipesWithFilters = () => {
   const { classes } = useStyles()
@@ -16,7 +17,7 @@ const SwipesWithFilters = () => {
   }
 
   return (
-    <Box>
+    <Box className={classes.boxSwipesWithFilters}>
       <Link className={classes.filters} onClick={handleOpenFiltersDialog}>
         filters
       </Link>
@@ -39,5 +40,10 @@ const useStyles = makeStyles()({
     textDecorationColor: '#262626',
     // marginTop: -71,
     paddingBottom: 35,
+  },
+  boxSwipesWithFilters: {
+    [theme.breakpoints.down('sm')]: {
+      marginTop: 20,
+    },
   },
 })

--- a/src/components/swipes/SwipesWithFilters.tsx
+++ b/src/components/swipes/SwipesWithFilters.tsx
@@ -1,0 +1,43 @@
+import { Box, Link } from '@mui/material'
+import Swipes from './Swipes'
+import NoMoreMatchesDialog from 'pages/NoMoreMatchesDialog'
+import { makeStyles } from 'tss-react/mui'
+import { useRef } from 'react'
+
+const SwipesWithFilters = () => {
+  const { classes } = useStyles()
+
+  const FiltersDialogRef = useRef<{
+    handleOpenNoMoreMatchesDialog: () => void
+  }>(null)
+
+  const handleOpenFiltersDialog = () => {
+    FiltersDialogRef.current?.handleOpenNoMoreMatchesDialog()
+  }
+
+  return (
+    <Box>
+      <Link className={classes.filters} onClick={handleOpenFiltersDialog}>
+        filters
+      </Link>
+      <Swipes />
+      <NoMoreMatchesDialog ref={FiltersDialogRef} title="Filters" />
+    </Box>
+  )
+}
+
+export default SwipesWithFilters
+
+const useStyles = makeStyles()({
+  filters: {
+    fontSize: 24,
+    lineHeight: 1.5,
+    color: '#262626',
+    textAlign: 'right',
+    display: 'block',
+    paddingRight: 20,
+    textDecorationColor: '#262626',
+    // marginTop: -71,
+    paddingBottom: 35,
+  },
+})

--- a/src/components/tabsMessagesFriends/Messages.tsx
+++ b/src/components/tabsMessagesFriends/Messages.tsx
@@ -6,6 +6,7 @@ import { UserLastMessage } from 'types/UserLastMessage'
 import NoNewMatches from './NoNewMatchesOrMessages'
 import { UserChatProfile } from 'types/UserProfileData'
 import { useLastMessagesList } from 'hooks/useLastMessagesList'
+import theme from '../../styles/createTheme'
 
 const Messages = ({ onClick }: any) => {
   const { classes } = useStyles()
@@ -29,7 +30,7 @@ const Messages = ({ onClick }: any) => {
     )
   }
   return (
-    <Box sx={{ maxHeight: 'calc(100vh - 290px)', overflow: 'auto' }}>
+    <Box className={classes.messagePage}>
       {userMessages?.map((element) => (
         <Box key={element.id} onClick={() => handleClick(element)}>
           <Box
@@ -66,9 +67,16 @@ export default Messages
 
 const useStyles = makeStyles()(() => {
   return {
+    messagePage: {
+      maxHeight: 'calc(100vh - 290px)',
+      overflow: 'auto',
+      [theme.breakpoints.down('sm')]: {
+        maxHeight: 'calc(100vh - 137px)',
+      },
+    },
     messageBlock: {
       display: 'grid',
-      gridTemplateColumns: '0.5fr 5fr 0.5fr',
+      gridTemplateColumns: '66px 1fr 30px',
       alignItems: 'center',
       padding: '30px 21px 20px 10px',
     },
@@ -78,6 +86,7 @@ const useStyles = makeStyles()(() => {
     message: {
       paddingLeft: 15,
       paddingRight: 19,
+      minWidth: 0,
     },
     messageQuantity: {
       borderRadius: '50%',
@@ -100,7 +109,7 @@ const useStyles = makeStyles()(() => {
     textMessage: {
       fontSize: 14,
       lineHeight: '22px',
-      width: 210,
+      maxWidth: '100%',
       whiteSpace: 'nowrap',
       overflow: 'hidden',
       textOverflow: 'ellipsis',

--- a/src/components/tabsMessagesFriends/TabsMessagesFriends.tsx
+++ b/src/components/tabsMessagesFriends/TabsMessagesFriends.tsx
@@ -50,9 +50,7 @@ const TabsMessagesFriends: React.FC = () => {
   return (
     <Box sx={{ maxWidth: '1024px', margin: '0 auto' }}>
       {showTabs && (
-        <Box
-          sx={{ maxWidth: '419px', paddingBottom: '38px', paddingTop: '10px' }}
-        >
+        <Box className={classes.tabsBlock}>
           {isMobile ? (
             <Box
               onClick={() => setMobileTab('messages')}
@@ -133,5 +131,11 @@ const useStyles = makeStyles()({
   },
   removeIndicator: {
     display: 'none',
+  },
+  tabsBlock: {
+    maxWidth: '419px',
+    paddingBottom: '38px',
+    paddingTop: '10px',
+    display: 'flex',
   },
 })

--- a/src/components/tabsMessagesFriends/TabsMessagesFriends.tsx
+++ b/src/components/tabsMessagesFriends/TabsMessagesFriends.tsx
@@ -38,13 +38,11 @@ const TabsMessagesFriends: React.FC = () => {
     return active ? theme.palette.primary.dark : theme.palette.text.primary
   }
 
-  const handleClick = () => {
-    console.log('Add page for writing messages on mobile')
+  const handleOpenChatPage = () => {
     // TODO:  Open page for chat between two users
   }
 
-  const handleOnClick = () => {
-    console.log('Add page for showing friends page')
+  const handleShowFriendProfile = () => {
     // TODO: Open page with friends profile
   }
   return (
@@ -105,9 +103,9 @@ const TabsMessagesFriends: React.FC = () => {
         (isMobile ? (
           pathname === '/messages' ? (
             mobileTab === 'messages' ? (
-              <Messages onClick={handleClick} />
+              <Messages onClick={handleOpenChatPage} />
             ) : (
-              <Friends onClick={handleOnClick} />
+              <Friends onClick={handleShowFriendProfile} />
             )
           ) : pathname === '/friends' ? (
             <SwipesWithFilters />
@@ -137,5 +135,8 @@ const useStyles = makeStyles()({
     paddingBottom: '38px',
     paddingTop: '10px',
     display: 'flex',
+    [theme.breakpoints.down('sm')]: {
+      paddingTop: '40px',
+    },
   },
 })

--- a/src/components/tabsMessagesFriends/TabsMessagesFriends.tsx
+++ b/src/components/tabsMessagesFriends/TabsMessagesFriends.tsx
@@ -1,46 +1,122 @@
 import * as React from 'react'
-import { Box } from '@mui/material'
+import { Box, useMediaQuery } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import { useNewFriendsList } from 'hooks/useFriendsList'
 import { Link, Outlet, useLocation } from 'react-router-dom'
 import theme from '../../styles/createTheme'
+import Messages from './Messages'
+import { useEffect, useState } from 'react'
+import Friends from './Friends'
+import Swipes from 'components/swipes/Swipes'
 
 const TabsMessagesFriends: React.FC = () => {
   const { classes } = useStyles()
-  const location = useLocation().pathname
+  const location = useLocation()
+  const { pathname } = location
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
   const { data: friendsList } = useNewFriendsList()
 
-  const getColor = (path: string): string => {
-    return path === location
-      ? theme.palette.primary.dark
-      : theme.palette.text.primary
+  // local status for mobile
+  const [mobileTab, setMobileTab] = useState<'messages' | 'friends'>('messages')
+
+  useEffect(() => {
+    if (isMobile && pathname === '/messages') {
+      setMobileTab('messages')
+    }
+  }, [pathname, isMobile])
+
+  const showTabs = !isMobile || pathname === '/messages'
+  const showContent =
+    !isMobile || pathname === '/friends' || pathname === '/messages'
+
+  const getColor = (tab: 'messages' | 'friends'): string => {
+    const active = isMobile
+      ? mobileTab === tab
+      : (tab === 'messages' ? '/messages' : '/friends') === pathname
+
+    return active ? theme.palette.primary.dark : theme.palette.text.primary
   }
 
+  const handleClick = () => {
+    console.log('Add page for writing messages on mobile')
+    // TODO:  Open page for chat between two users
+  }
+
+  const handleOnClick = () => {
+    console.log('Add page for showing friends page')
+    // TODO: Open page with friends profile
+  }
   return (
     <Box sx={{ maxWidth: '1024px', margin: '0 auto' }}>
-      <Box
-        sx={{ maxWidth: '419px', paddingBottom: '38px', paddingTop: '10px' }}
-      >
-        <Link
-          to="/messages"
-          style={{
-            color: getColor('/messages'),
-            paddingRight: '60px',
-          }}
-          className={classes.labelStyle}
+      {showTabs && (
+        <Box
+          sx={{ maxWidth: '419px', paddingBottom: '38px', paddingTop: '10px' }}
         >
-          Messages
-        </Link>
-        <Link
-          to="/friends"
-          style={{
-            color: getColor('/friends'),
-          }}
-          className={classes.labelStyle}
-        >{`New friends (${friendsList?.length})`}</Link>
-      </Box>
-      <Outlet />
+          {isMobile ? (
+            <Box
+              onClick={() => setMobileTab('messages')}
+              style={{
+                color: getColor('messages'),
+                paddingRight: '60px',
+                cursor: 'pointer',
+              }}
+              className={classes.labelStyle}
+            >
+              Messages
+            </Box>
+          ) : (
+            <Link
+              to="/messages"
+              style={{
+                color: getColor('messages'),
+                paddingRight: '60px',
+              }}
+              className={classes.labelStyle}
+            >
+              Messages
+            </Link>
+          )}
+          {/* New Friends Tab */}
+          {isMobile ? (
+            <Box
+              onClick={() => setMobileTab('friends')}
+              style={{
+                color: getColor('friends'),
+                cursor: 'pointer',
+              }}
+              className={classes.labelStyle}
+            >
+              {`New friends (${friendsList?.length})`}
+            </Box>
+          ) : (
+            <Link
+              to="/friends"
+              style={{
+                color: getColor('friends'),
+              }}
+              className={classes.labelStyle}
+            >
+              {`New friends (${friendsList?.length})`}
+            </Link>
+          )}
+        </Box>
+      )}
+      {/*  Content: for mobile, we render components directly, for desktop - via Outlet */}
+      {showContent &&
+        (isMobile ? (
+          pathname === '/messages' ? (
+            mobileTab === 'messages' ? (
+              <Messages onClick={handleClick} />
+            ) : (
+              <Friends onClick={handleOnClick} />
+            )
+          ) : pathname === '/friends' ? (
+            <Swipes />
+          ) : null
+        ) : (
+          <Outlet />
+        ))}
     </Box>
   )
 }

--- a/src/components/tabsMessagesFriends/TabsMessagesFriends.tsx
+++ b/src/components/tabsMessagesFriends/TabsMessagesFriends.tsx
@@ -7,7 +7,7 @@ import theme from '../../styles/createTheme'
 import Messages from './Messages'
 import { useEffect, useState } from 'react'
 import Friends from './Friends'
-import Swipes from 'components/swipes/Swipes'
+import SwipesWithFilters from 'components/swipes/SwipesWithFilters'
 
 const TabsMessagesFriends: React.FC = () => {
   const { classes } = useStyles()
@@ -110,7 +110,7 @@ const TabsMessagesFriends: React.FC = () => {
               <Friends onClick={handleOnClick} />
             )
           ) : pathname === '/friends' ? (
-            <Swipes />
+            <SwipesWithFilters />
           ) : null
         ) : (
           <Outlet />

--- a/src/components/userProfile/PhotoCarousel.tsx
+++ b/src/components/userProfile/PhotoCarousel.tsx
@@ -32,8 +32,12 @@ const PhotoCarousel: React.FC<PhotoCarouselProps> = ({ items, className }) => {
         indicatorContainerProps={{
           style: {
             position: 'absolute',
-            marginTop: -535,
+            top: 0,
+            left: 0,
+            right: 0,
             zIndex: 200,
+            display: 'flex',
+            justifyContent: 'center',
           },
         }}
         navButtonsProps={{
@@ -46,7 +50,9 @@ const PhotoCarousel: React.FC<PhotoCarouselProps> = ({ items, className }) => {
         }}
         NextIcon={<ArrowForwardIos style={{ fontSize: 23 }} />}
         PrevIcon={<ArrowBackIosNew style={{ fontSize: 23 }} />}
-        sx={{ height: 535 }}
+        sx={{
+          height: { xs: 420, sm: 535 },
+        }}
       >
         {items.map((item: UserPhoto, i: number) => (
           <UserPic key={i} src={item.src} />

--- a/src/components/userProfile/UserPic.tsx
+++ b/src/components/userProfile/UserPic.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-
 import { makeStyles } from 'tss-react/mui'
+import theme from '../../styles/createTheme'
 
 interface UserPicProps {
   src: string
@@ -13,13 +13,16 @@ const UserPic: React.FC<UserPicProps> = ({ src }) => {
 
 export default UserPic
 
-const useStyles = makeStyles()(() => {
-  return {
-    foto: {
-      width: '100%',
-      height: '535px',
-      objectFit: 'cover',
-      display: 'block',
+const useStyles = makeStyles()({
+  foto: {
+    width: '100%',
+    height: 'auto',
+    aspectRatio: '3 / 4',
+    objectFit: 'cover',
+    display: 'block',
+    maxHeight: 535,
+    [theme.breakpoints.down('sm')]: {
+      maxHeight: 420,
     },
-  }
+  },
 })

--- a/src/components/userProfile/UserProfile.tsx
+++ b/src/components/userProfile/UserProfile.tsx
@@ -178,6 +178,9 @@ const useStyles = makeStyles()(() => {
       fontSize: 40,
       fontWeight: 600,
       lineHeight: '40px',
+      [theme.breakpoints.down('sm')]: {
+        fontSize: 32,
+      },
     },
     roundIcon: {
       fill: '#77BD65',
@@ -194,6 +197,9 @@ const useStyles = makeStyles()(() => {
       fontSize: 18,
       lineHeight: '20px',
       paddingLeft: 4,
+      [theme.breakpoints.down('sm')]: {
+        fontSize: 14,
+      },
     },
     title: {
       color: '#F1562A',
@@ -236,7 +242,7 @@ const useStyles = makeStyles()(() => {
     },
     reasons: {
       display: 'grid',
-      gridTemplateColumns: '180px 180px ',
+      gridTemplateColumns: '1fr 1fr ',
       gap: 15,
       '&MuiList-root': {
         paddingBottom: 0,

--- a/src/pages/FriendsPage.tsx
+++ b/src/pages/FriendsPage.tsx
@@ -1,13 +1,12 @@
-import { useState, useRef } from 'react'
-import { Box, Link } from '@mui/material'
+import { useState } from 'react'
+import { Box } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import UserProfile from 'components/userProfile/UserProfile'
 import UserProfileButton from 'components/userProfile/UserProfileButton'
 import { UserProfileData } from 'types/UserProfileData'
 import Friends from 'components/tabsMessagesFriends/Friends'
 import { useNavigate } from 'react-router-dom'
-import Swipes from 'components/swipes/Swipes'
-import NoMoreMatchesDialog from 'pages/NoMoreMatchesDialog'
+import SwipesWithFilters from 'components/swipes/SwipesWithFilters'
 
 const FriendsPage = () => {
   const { classes } = useStyles()
@@ -15,14 +14,6 @@ const FriendsPage = () => {
   const [friendsData, setFriendsData] = useState<UserProfileData | null>(null)
 
   const navigate = useNavigate()
-
-  const FiltersDialogRef = useRef<{
-    handleOpenNoMoreMatchesDialog: () => void
-  }>(null)
-
-  const handleOpenFiltersDialog = () => {
-    FiltersDialogRef.current?.handleOpenNoMoreMatchesDialog()
-  }
 
   const selectFriend = (user: UserProfileData) => {
     setFriendsData(user)
@@ -41,14 +32,10 @@ const FriendsPage = () => {
           <UserProfileButton startChat={startChat} />
         </Box>
       ) : (
-        <Box>
-          <Link className={classes.filters} onClick={handleOpenFiltersDialog}>
-            filters
-          </Link>
-          <Swipes />
+        <Box sx={{ marginTop: '-71px' }}>
+          <SwipesWithFilters />
         </Box>
       )}
-      <NoMoreMatchesDialog ref={FiltersDialogRef} title="Filters" />
     </Box>
   )
 }

--- a/src/pages/MessagesPage.tsx
+++ b/src/pages/MessagesPage.tsx
@@ -1,11 +1,10 @@
-import { useState, useRef } from 'react'
+import { useState } from 'react'
 import {
   Box,
   Typography,
   Button,
   TextareaAutosize,
   Avatar,
-  Link,
 } from '@mui/material'
 import { makeStyles } from 'tss-react/mui'
 import Messages from 'components/tabsMessagesFriends/Messages'
@@ -15,21 +14,12 @@ import { UserChatProfile } from 'types/UserProfileData'
 import StartChatting from 'components/chat/StartChatting'
 import DisplayingChat from 'components/chat/DisplayingChat'
 import messages from '../components/chat/chat.json'
-import Swipes from 'components/swipes/Swipes'
-import NoMoreMatchesDialog from 'pages/NoMoreMatchesDialog'
+import SwipesWithFilters from 'components/swipes/SwipesWithFilters'
 
 const MessagesPage = () => {
   const { classes } = useStyles()
   const [selectedChat, setSelectedChat] = useState<UserChatProfile | null>(null)
   const userId = '1'
-
-  const FiltersDialogRef = useRef<{
-    handleOpenNoMoreMatchesDialog: () => void
-  }>(null)
-
-  const handleOpenFiltersDialog = () => {
-    FiltersDialogRef.current?.handleOpenNoMoreMatchesDialog()
-  }
 
   const frienId = messages.participants.find((el) => el !== userId)
 
@@ -100,15 +90,11 @@ const MessagesPage = () => {
             </Box>
           </Box>
         ) : (
-          <Box>
-            <Link className={classes.filters} onClick={handleOpenFiltersDialog}>
-              filters
-            </Link>
-            <Swipes />
+          <Box sx={{ marginTop: '-71px' }}>
+            <SwipesWithFilters />
           </Box>
         )}
       </Box>
-      <NoMoreMatchesDialog ref={FiltersDialogRef} title="Filters" />
     </Box>
   )
 }


### PR DESCRIPTION
Task: https://app.clickup.com/t/8698h9h7n

- implemented mobile layout for messages and friends pages
- On desktop: tabs and swipes are visible on both pages
- On mobile:
  • Tabs appear only on /messages
  • Swipes appear only on /friends